### PR TITLE
add parsing for remainder of bitsy gamedata format + add serialization

### DIFF
--- a/lib/colourUtils.ts
+++ b/lib/colourUtils.ts
@@ -1,8 +1,10 @@
-export function numToRgbString(num: number) {
+export function numToRgbString(num: number)
+{
     return `${(num >> 16) & 255},${(num >> 8) & 255},${num & 255}`;
 }
 
-export function rgbStringToNum(str: string) {
+export function rgbStringToNum(str: string)
+{
     const [r, g, b] = str.split(",");
     return (parseInt(b, 10) << 0) | (parseInt(g, 10) << 8) | (parseInt(r, 10) << 16);
 }

--- a/lib/colourUtils.ts
+++ b/lib/colourUtils.ts
@@ -1,0 +1,8 @@
+export function numToRgbString(num: number) {
+    return `${(num >> 16) & 255},${(num >> 8) & 255},${num & 255}`;
+}
+
+export function rgbStringToNum(str: string) {
+    const [r, g, b] = str.split(",");
+    return (parseInt(b, 10) << 0) | (parseInt(g, 10) << 8) | (parseInt(r, 10) << 16);
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,31 @@ export class BitsyWorld
     public tiles: {[index:string]: BitsyTile} = {};
     public sprites: {[index:string]: BitsySprite} = {};
     public items: {[index:string]: BitsyItem} = {};
+    public toString() {
+        function valuesToString(obj: {[index:string]: BitsyResource}) {
+            return Object.keys(obj).map(s => obj[s].toString()).join('\n\n');
+        }
+        return `
+TODO: title
+
+TODO: version
+
+TODO: room format
+
+TODO: palettes
+
+TODO: rooms
+
+${valuesToString(this.tiles)}
+
+${valuesToString(this.sprites)}
+
+${valuesToString(this.items)}
+
+TODO: dialogue
+
+TODO: variables`
+    }
 }
 
 export interface BitsyResource
@@ -41,6 +66,27 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
         const bob = <typeof BitsyObjectBase>this.constructor;
         return bob;
     }
+    public toString() {
+        const props = [];
+        props.push(`${this.type.typeName} ${this.id}`);
+        props.push(this.graphic.map(g => g.map(b => b ? 1 : 0).join(',').replace(/((?:.,){7}.),/g, '$1\n')).join('\n>\n'));
+        if (this.name) {
+            props.push(`NAME ${this.name}`);
+        }
+        if (this.dialogueID) {
+            props.push(`DLG ${this.dialogueID}`);
+        }
+        if (this.position) {
+            props.push(`POS ${this.position.room} ${this.position.x},${this.position.y}`);
+        }
+        if (this.wall) {
+            props.push(`WAL true`);
+        }
+        if (this.palette !== this.type.paletteDefault) {
+            props.push(`COL ${this.palette}`);
+        }
+        return props.join('\n');
+    };
 }
 
 export class BitsyTile extends BitsyObjectBase

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -56,7 +56,7 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
     public graphic: BitsyGraphic = [];
     public palette: number;
     public dialogueID: string = "";
-    public position?: { room: String, x: Number, y: Number };
+    public position?: { room: string, x: number, y: number };
     public wall: boolean = false;
     constructor() {
         super();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -102,7 +102,7 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
     {
         const props = [];
         props.push(super.toString());
-        props.push(this.graphic.map(g => g.map(b => b ? 1 : 0).join(',').replace(/((?:.,){7}.),/g, '$1\n')).join('\n>\n').replace(/,/g,''));
+        props.push(this.graphic.map(g => g.map(b => b ? 1 : 0).join('').replace(/(.{8})/g, '$1\n')).join('\n>\n'));
         if (this.name)
         {
             props.push(`NAME ${this.name}`);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,6 +45,7 @@ export class BitsySprite extends BitsyObjectBase
 {
     static paletteDefault: number = 2;
     public dialogueID: string = "";
+    public position?: { room: String, x: Number, y: Number };
 }
 
 export class BitsyItem extends BitsyObjectBase
@@ -199,6 +200,16 @@ export class BitsyParser
         }
     }
 
+    private tryTakeSpritePosition(sprite: BitsySprite)
+    {
+        if (this.checkLine("POS"))
+        {
+            const [room, pos] = this.takeSplitOnce(" ")[1].split(" ");
+            const [x, y] = pos.split(",");
+            sprite.position = { room, x: parseInt(x, 10), y: parseInt(y, 10) };
+        }
+    }
+
     private takePalette(): void
     {
         const palette = new BitsyPalette();
@@ -266,6 +277,7 @@ export class BitsyParser
         this.takeObjectGraphic(sprite);
         this.tryTakeResourceName(sprite);
         this.tryTakeObjectDialogueID(sprite);
+        this.tryTakeSpritePosition(sprite);
         this.tryTakeObjectPalette(sprite);
 
         this.world.sprites[sprite.id] = sprite;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,6 +15,7 @@ export class BitsyWorld
     public tiles: {[index:string]: BitsyTile} = {};
     public sprites: {[index:string]: BitsySprite} = {};
     public items: {[index:string]: BitsyItem} = {};
+    public dialogue: {[index:string]: BitsyDialogue} = {};
     public variables: {[index:string]: BitsyVariable} = {};
     public toString() {
         function valuesToString(obj: {[index:string]: BitsyResource}) {
@@ -36,7 +37,7 @@ ${valuesToString(this.sprites)}
 
 ${valuesToString(this.items)}
 
-TODO: dialogue
+${valuesToString(this.dialogue)}
 
 ${valuesToString(this.variables)}`
     }
@@ -162,6 +163,17 @@ export class BitsyRoom extends BitsyResourceBase
     }
 }
 
+export class BitsyDialogue extends BitsyResourceBase
+{
+    static typeName: string = "DLG";
+    public script: string = "";
+
+    public toString() {
+        return `${super.toString()}
+${this.script}`;
+    }
+}
+
 export class BitsyVariable extends BitsyResourceBase
 {
     static typeName: string = "VAR";
@@ -216,6 +228,7 @@ export class BitsyParser
             else if (this.checkLine("TIL")) this.takeTile();
             else if (this.checkLine("SPR")) this.takeSprite();
             else if (this.checkLine("ITM")) this.takeItem();
+            else if (this.checkLine("DLG")) this.takeDialogue();
             else if (this.checkLine("VAR")) this.takeVariable();
             else
             {
@@ -386,6 +399,19 @@ export class BitsyParser
         room.palette = this.takeSplitOnce(" ")[1];
     }
 
+    private takeDialogueScript(dialogue: BitsyDialogue) {
+        if (this.checkLine('"""')) {
+            const lines = [this.takeLine()];
+            while (!this.checkLine('"""')) {
+                lines.push(this.takeLine());
+            }
+            lines.push(this.takeLine());
+            dialogue.script = lines.join('\n');
+        } else {
+            dialogue.script = this.takeLine();
+        }
+    }
+
     private takeFrame(): BitsyGraphicFrame
     {
         const frame: BitsyGraphicFrame = new Array(64).fill(false);
@@ -456,6 +482,15 @@ export class BitsyParser
         this.tryTakeObjectPalette(item);
 
         this.world.items[item.id] = item;
+    }
+
+    private takeDialogue(): void
+    {
+        const dialogue = new BitsyDialogue();
+        this.takeResourceID(dialogue);
+        this.takeDialogueScript(dialogue);
+
+        this.world.dialogue[dialogue.id] = dialogue;
     }
 
     private takeVariable(): void

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,14 +45,18 @@ export interface BitsyObject extends BitsyResource
 
 export class BitsyResourceBase implements BitsyResource
 {
+    static typeName: string = "";
     public id: string = "";
     public name: string = "";
+    get type() {
+        const brb = <typeof BitsyResourceBase>this.constructor;
+        return brb;
+    }
 }
 
 export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
 {
     static paletteDefault: number = 1;
-    static typeName: string = "";
     public graphic: BitsyGraphic = [];
     public palette: number;
     public dialogueID: string = "";
@@ -112,6 +116,7 @@ export type BitsyGraphic = BitsyGraphicFrame[];
 
 export class BitsyPalette extends BitsyResourceBase
 {
+    static typeName: string = "PAL";
     public colors: number[] = [];
 
     public constructor()

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,6 +17,7 @@ export class BitsyWorld
     public sprites: { [index: string]: BitsySprite } = {};
     public items: { [index: string]: BitsyItem } = {};
     public dialogue: { [index: string]: BitsyDialogue } = {};
+    public endings: { [index: string]: BitsyEnding } = {};
     public variables: { [index: string]: BitsyVariable } = {};
 
     public toString()
@@ -42,6 +43,8 @@ ${valuesToString(this.sprites)}
 ${valuesToString(this.items)}
 
 ${valuesToString(this.dialogue)}
+
+${valuesToString(this.endings)}
 
 ${valuesToString(this.variables)}`
     }
@@ -193,6 +196,18 @@ ${this.script}`;
     }
 }
 
+export class BitsyEnding extends BitsyResourceBase
+{
+    static typeName: string = "END";
+    public script: string = "";
+
+    public toString()
+    {
+        return `${super.toString()}
+${this.script}`;
+    }
+}
+
 export class BitsyVariable extends BitsyResourceBase
 {
     static typeName: string = "VAR";
@@ -250,6 +265,7 @@ export class BitsyParser
             else if (this.checkLine("TIL")) this.takeTile();
             else if (this.checkLine("SPR")) this.takeSprite();
             else if (this.checkLine("ITM")) this.takeItem();
+            else if (this.checkLine("END")) this.takeEnding();
             else if (this.checkLine("DLG")) this.takeDialogue();
             else if (this.checkLine("VAR")) this.takeVariable();
             else
@@ -515,6 +531,14 @@ export class BitsyParser
         this.tryTakeObjectPalette(item);
 
         this.world.items[item.id] = item;
+    }
+
+    private takeEnding(): void {
+        const ending = new BitsyEnding();
+        this.takeResourceID(ending);
+        this.takeDialogueScript(ending);
+
+        this.world.endings[ending.id] = ending;
     }
 
     private takeDialogue(): void

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -221,10 +221,9 @@ export class BitsyParser
     {
         const [r, g, b] = this.takeSplit(",");
         
-        return (parseInt(r) <<  0)
-             | (parseInt(g) <<  8)
-             | (parseInt(b) << 16)
-             | (255         << 24);
+        return (parseInt(b, 10) <<  0)
+             | (parseInt(g, 10) <<  8)
+             | (parseInt(r, 10) << 16);
     }
 
     private takeResourceID(resource: BitsyResource)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -32,6 +32,7 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
     public palette: number;
     public dialogueID: string = "";
     public position?: { room: String, x: Number, y: Number };
+    public wall: boolean = false;
     constructor() {
         super();
         this.palette = this.type.paletteDefault;
@@ -216,6 +217,14 @@ export class BitsyParser
         }
     }
 
+    private tryTakeTileWall(tile: BitsyObjectBase)
+    {
+        if (this.checkLine("WAL"))
+        {
+            tile.wall = this.takeSplitOnce(" ")[1] === "true";
+        }
+    }
+
     private takePalette(): void
     {
         const palette = new BitsyPalette();
@@ -271,6 +280,7 @@ export class BitsyParser
         this.takeResourceID(tile);
         this.takeObjectGraphic(tile);
         this.tryTakeResourceName(tile);
+        this.tryTakeTileWall(tile);
         this.tryTakeObjectPalette(tile);
 
         this.world.tiles[tile.id] = tile;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -60,6 +60,9 @@ export class BitsyResourceBase implements BitsyResource
         const brb = <typeof BitsyResourceBase>this.constructor;
         return brb;
     }
+    public toString() {
+        return `${this.type.typeName} ${this.id}`;
+    }
 }
 
 export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
@@ -80,7 +83,7 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
     }
     public toString() {
         const props = [];
-        props.push(`${this.type.typeName} ${this.id}`);
+        props.push(super.toString());
         props.push(this.graphic.map(g => g.map(b => b ? 1 : 0).join(',').replace(/((?:.,){7}.),/g, '$1\n')).join('\n>\n'));
         if (this.name) {
             props.push(`NAME ${this.name}`);
@@ -131,7 +134,7 @@ export class BitsyPalette extends BitsyResourceBase
     public get tile(): number { return this.colors[1]; }
     public get sprite(): number { return this.colors[2]; }
     public toString() {
-        return `${this.type.typeName} ${this.id}
+        return `${super.toString()}
 ${this.colors.map(numToRgbString).join('\n')}`;
     }
 }
@@ -147,7 +150,7 @@ export class BitsyRoom extends BitsyResourceBase
 
     public toString() {
         return [
-            `${this.type.typeName} ${this.id}`,
+            super.toString(),
             ...this.tiles.map(row => row.join(",")),
             ...this.items.map(({ id, x, y }) => `ITM ${id} ${x},${y}`),
             ...this.exits.map(({ from, to, transition }) => `EXT ${from.x},${from.y} ${to.room} ${to.x},${to.y}${transition ? ` FX ${transition}` : ""}`),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -534,7 +534,8 @@ export class BitsyParser
         this.world.items[item.id] = item;
     }
 
-    private takeEnding(): void {
+    private takeEnding(): void
+    {
         const ending = new BitsyEnding();
         this.takeResourceID(ending);
         this.takeDialogueScript(ending);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -29,6 +29,8 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
     static paletteDefault: number = 1;
     public graphic: BitsyGraphic = [];
     public palette: number;
+    public dialogueID: string = "";
+    public position?: { room: String, x: Number, y: Number };
     constructor() {
         super();
         this.palette = this.type.paletteDefault;
@@ -47,14 +49,11 @@ export class BitsyTile extends BitsyObjectBase
 export class BitsySprite extends BitsyObjectBase
 {
     static paletteDefault: number = 2;
-    public dialogueID: string = "";
-    public position?: { room: String, x: Number, y: Number };
 }
 
 export class BitsyItem extends BitsyObjectBase
 {
     static paletteDefault: number = 2;
-    public dialogueID: string = "";
 }
 
 export type BitsyGraphicFrame = boolean[];
@@ -203,7 +202,7 @@ export class BitsyParser
         }
     }
 
-    private tryTakeSpritePosition(sprite: BitsySprite)
+    private tryTakeSpritePosition(sprite: BitsyObjectBase)
     {
         if (this.checkLine("POS"))
         {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -102,7 +102,7 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
     {
         const props = [];
         props.push(super.toString());
-        props.push(this.graphic.map(g => g.map(b => b ? 1 : 0).join(',').replace(/((?:.,){7}.),/g, '$1\n')).join('\n>\n'));
+        props.push(this.graphic.map(g => g.map(b => b ? 1 : 0).join(',').replace(/((?:.,){7}.),/g, '$1\n')).join('\n>\n').replace(/,/g,''));
         if (this.name)
         {
             props.push(`NAME ${this.name}`);
@@ -180,6 +180,7 @@ export class BitsyRoom extends BitsyResourceBase
             ...this.items.map(({ id, x, y }) => `ITM ${id} ${x},${y}`),
             ...this.exits.map(({ from, to, transition }) => `EXT ${from.x},${from.y} ${to.room} ${to.x},${to.y}${transition ? ` FX ${transition}` : ""}`),
             ...this.endings.map(({ id, x, y }) => `END ${id} ${x},${y}`),
+            `PAL ${this.palette}`,
         ].join('\n');
     }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,8 +31,11 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
     public palette: number;
     constructor() {
         super();
+        this.palette = this.type.paletteDefault;
+    }
+    get type() {
         const bob = <typeof BitsyObjectBase>this.constructor;
-        this.palette = bob.paletteDefault;
+        return bob;
     }
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
+import { numToRgbString, rgbStringToNum } from "./colourUtils";
+
 export class BitsyWorld
 {
     public palettes: {[index:string]: BitsyPalette} = {};
@@ -131,7 +133,7 @@ export class BitsyPalette extends BitsyResourceBase
     public get sprite(): number { return this.colors[2]; }
     public toString() {
         return `${this.type.typeName} ${this.id}
-${this.colors.map(c => `${(c >> 16) & 255},${(c >> 8) & 255},${c & 255}`).join('\n')}`;
+${this.colors.map(numToRgbString).join('\n')}`;
     }
 }
 
@@ -228,11 +230,7 @@ export class BitsyParser
 
     private takeColor(): number
     {
-        const [r, g, b] = this.takeSplit(",");
-        
-        return (parseInt(b, 10) <<  0)
-             | (parseInt(g, 10) <<  8)
-             | (parseInt(r, 10) << 16);
+        return rgbStringToNum(this.takeLine());
     }
 
     private takeResourceID(resource: BitsyResource)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -102,7 +102,7 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
     {
         const props = [];
         props.push(super.toString());
-        props.push(this.graphic.map(g => g.map(b => b ? 1 : 0).join('').replace(/(.{8})/g, '$1\n')).join('\n>\n'));
+        props.push(this.graphic.map(g => g.map(b => b ? 1 : 0).join('').replace(/(.{8})/g, '$1\n')).join('\n>\n').trim());
         if (this.name)
         {
             props.push(`NAME ${this.name}`);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import { numToRgbString, rgbStringToNum } from "./colourUtils";
 
-function parsePosition(str: string) {
+function parsePosition(str: string)
+{
     const [x, y] = str.split(",").map(n => parseInt(n, 10));
     return { x, y };
 }
@@ -10,15 +11,18 @@ export class BitsyWorld
     public title: string = "";
     public bitsyVersion: string = "";
     public roomFormat: number = 1;
-    public rooms: {[index:string]: BitsyRoom} = {};
-    public palettes: {[index:string]: BitsyPalette} = {};
-    public tiles: {[index:string]: BitsyTile} = {};
-    public sprites: {[index:string]: BitsySprite} = {};
-    public items: {[index:string]: BitsyItem} = {};
-    public dialogue: {[index:string]: BitsyDialogue} = {};
-    public variables: {[index:string]: BitsyVariable} = {};
-    public toString() {
-        function valuesToString(obj: {[index:string]: BitsyResource}) {
+    public rooms: { [index: string]: BitsyRoom } = {};
+    public palettes: { [index: string]: BitsyPalette } = {};
+    public tiles: { [index: string]: BitsyTile } = {};
+    public sprites: { [index: string]: BitsySprite } = {};
+    public items: { [index: string]: BitsyItem } = {};
+    public dialogue: { [index: string]: BitsyDialogue } = {};
+    public variables: { [index: string]: BitsyVariable } = {};
+
+    public toString()
+    {
+        function valuesToString(obj: { [index: string]: BitsyResource })
+        {
             return Object.keys(obj).map(s => obj[s].toString()).join('\n\n');
         }
         return `${this.title}
@@ -60,11 +64,14 @@ export class BitsyResourceBase implements BitsyResource
     static typeName: string = "";
     public id: string = "";
     public name: string = "";
-    get type() {
+
+    get type()
+    {
         const brb = <typeof BitsyResourceBase>this.constructor;
         return brb;
     }
-    public toString() {
+    public toString()
+    {
         return `${this.type.typeName} ${this.id}`;
     }
 }
@@ -77,31 +84,40 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
     public dialogueID: string = "";
     public position?: { room: string, x: number, y: number };
     public wall: boolean = false;
-    constructor() {
+
+    constructor()
+    {
         super();
         this.palette = this.type.paletteDefault;
     }
-    get type() {
+    get type()
+    {
         const bob = <typeof BitsyObjectBase>this.constructor;
         return bob;
     }
-    public toString() {
+    public toString()
+    {
         const props = [];
         props.push(super.toString());
         props.push(this.graphic.map(g => g.map(b => b ? 1 : 0).join(',').replace(/((?:.,){7}.),/g, '$1\n')).join('\n>\n'));
-        if (this.name) {
+        if (this.name)
+        {
             props.push(`NAME ${this.name}`);
         }
-        if (this.dialogueID) {
+        if (this.dialogueID)
+        {
             props.push(`DLG ${this.dialogueID}`);
         }
-        if (this.position) {
+        if (this.position)
+        {
             props.push(`POS ${this.position.room} ${this.position.x},${this.position.y}`);
         }
-        if (this.wall) {
+        if (this.wall)
+        {
             props.push(`WAL true`);
         }
-        if (this.palette !== this.type.paletteDefault) {
+        if (this.palette !== this.type.paletteDefault)
+        {
             props.push(`COL ${this.palette}`);
         }
         return props.join('\n');
@@ -137,7 +153,8 @@ export class BitsyPalette extends BitsyResourceBase
     public get background(): number { return this.colors[0]; }
     public get tile(): number { return this.colors[1]; }
     public get sprite(): number { return this.colors[2]; }
-    public toString() {
+    public toString()
+    {
         return `${super.toString()}
 ${this.colors.map(numToRgbString).join('\n')}`;
     }
@@ -152,7 +169,8 @@ export class BitsyRoom extends BitsyResourceBase
     public endings: { id: string, x: number, y: number }[] = [];
     public palette: string = "";
 
-    public toString() {
+    public toString()
+    {
         return [
             super.toString(),
             ...this.tiles.map(row => row.join(",")),
@@ -168,7 +186,8 @@ export class BitsyDialogue extends BitsyResourceBase
     static typeName: string = "DLG";
     public script: string = "";
 
-    public toString() {
+    public toString()
+    {
         return `${super.toString()}
 ${this.script}`;
     }
@@ -179,7 +198,8 @@ export class BitsyVariable extends BitsyResourceBase
     static typeName: string = "VAR";
     public value: string = "";
 
-    public toString() {
+    public toString()
+    {
         return `${super.toString()}
 ${this.value}`;
     }
@@ -212,11 +232,13 @@ export class BitsyParser
         this.lines = lines;
 
         this.world.title = this.takeLine();
-        while(!this.done && !this.checkLine("# BITSY VERSION ")) {
+        while (!this.done && !this.checkLine("# BITSY VERSION "))
+        {
             this.skipLine();
         }
         this.world.bitsyVersion = this.takeSplitOnce("# BITSY VERSION ")[1];
-        while(!this.done && !this.checkLine("! ROOM_FORMAT ")) {
+        while (!this.done && !this.checkLine("! ROOM_FORMAT "))
+        {
             this.skipLine();
         }
         this.world.roomFormat = parseInt(this.takeSplitOnce("! ROOM_FORMAT ")[1], 10);
@@ -242,9 +264,9 @@ export class BitsyParser
         }
     }
 
-    private get done(): boolean 
-    { 
-        return this.lineCounter >= this.lines.length; 
+    private get done(): boolean
+    {
+        return this.lineCounter >= this.lines.length;
     }
 
     private get currentLine(): string
@@ -280,13 +302,13 @@ export class BitsyParser
     {
         return this.takeLine().split(delimiter);
     }
-    
-    private takeSplitOnce(delimiter: string) : [string, string]
+
+    private takeSplitOnce(delimiter: string): [string, string]
     {
         const line = this.takeLine();
         const i = line.indexOf(delimiter);
-        
-        return [line.slice(0, i), line.slice(i + delimiter.length)]; 
+
+        return [line.slice(0, i), line.slice(i + delimiter.length)];
     }
 
     private takeColor(): number
@@ -312,7 +334,7 @@ export class BitsyParser
         }
     }
 
-    private tryTakeObjectDialogueID(object: {"dialogueID": string})
+    private tryTakeObjectDialogueID(object: { "dialogueID": string })
     {
         if (this.checkLine("DLG"))
         {
@@ -356,13 +378,16 @@ export class BitsyParser
         const room = new BitsyRoom();
         this.takeResourceID(room);
         this.takeRoomTiles(room);
-        while (this.checkLine("ITM")) {
+        while (this.checkLine("ITM"))
+        {
             this.takeRoomItem(room);
         }
-        while (this.checkLine("EXT")) {
+        while (this.checkLine("EXT"))
+        {
             this.takeRoomExit(room);
         }
-        while (this.checkLine("END")) {
+        while (this.checkLine("END"))
+        {
             this.takeRoomEnding(room);
         }
         this.takeRoomPalette(room);
@@ -370,46 +395,53 @@ export class BitsyParser
         this.world.rooms[room.id] = room;
     }
 
-    private takeRoomTiles(room: BitsyRoom) {
-        for(let i = 0; i < 16; ++i) {
+    private takeRoomTiles(room: BitsyRoom)
+    {
+        for (let i = 0; i < 16; ++i)
+        {
             const row = this.takeSplit(",");
             room.tiles.push(row);
         }
     }
 
-    private takeRoomItem(room: BitsyRoom) {
+    private takeRoomItem(room: BitsyRoom)
+    {
         const item = this.takeSplitOnce(" ")[1];
         const [id, pos] = item.split(" ");
         room.items.push({ id, ...parsePosition(pos) });
     }
 
-    private takeRoomExit(room: BitsyRoom) {
+    private takeRoomExit(room: BitsyRoom)
+    {
         const exit = this.takeSplitOnce(" ")[1];
         const [from, toRoom, toPos, _, transition] = exit.split(" ");
         room.exits.push({ from: parsePosition(from), to: { room: toRoom, ...parsePosition(toPos) }, transition });
     }
 
-    private takeRoomEnding(room: BitsyRoom) {
+    private takeRoomEnding(room: BitsyRoom)
+    {
         const ending = this.takeSplitOnce(" ")[1];
         const [id, pos] = ending.split(" ");
         room.endings.push({ id, ...parsePosition(pos) });
     }
 
-    private takeRoomPalette(room: BitsyRoom) {
+    private takeRoomPalette(room: BitsyRoom)
+    {
         room.palette = this.takeSplitOnce(" ")[1];
     }
 
-    private takeDialogueScript(dialogue: BitsyDialogue) {
-        if (this.checkLine('"""')) {
+    private takeDialogueScript(dialogue: BitsyDialogue)
+    {
+        if (this.checkLine('"""'))
+        {
             const lines = [this.takeLine()];
-            while (!this.checkLine('"""')) {
+            while (!this.checkLine('"""'))
+            {
                 lines.push(this.takeLine());
             }
             lines.push(this.takeLine());
             dialogue.script = lines.join('\n');
-        } else {
-            dialogue.script = this.takeLine();
-        }
+        } else dialogue.script = this.takeLine();
     }
 
     private takeFrame(): BitsyGraphicFrame
@@ -438,7 +470,8 @@ export class BitsyParser
         {
             graphic.push(this.takeFrame());
             moreFrames = this.checkLine(">");
-            if(moreFrames) {
+            if (moreFrames)
+            {
                 this.skipLine();
             }
         }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,6 +15,7 @@ export class BitsyWorld
     public tiles: {[index:string]: BitsyTile} = {};
     public sprites: {[index:string]: BitsySprite} = {};
     public items: {[index:string]: BitsyItem} = {};
+    public variables: {[index:string]: BitsyVariable} = {};
     public toString() {
         function valuesToString(obj: {[index:string]: BitsyResource}) {
             return Object.keys(obj).map(s => obj[s].toString()).join('\n\n');
@@ -37,7 +38,7 @@ ${valuesToString(this.items)}
 
 TODO: dialogue
 
-TODO: variables`
+${valuesToString(this.variables)}`
     }
 }
 
@@ -161,6 +162,17 @@ export class BitsyRoom extends BitsyResourceBase
     }
 }
 
+export class BitsyVariable extends BitsyResourceBase
+{
+    static typeName: string = "VAR";
+    public value: string = "";
+
+    public toString() {
+        return `${super.toString()}
+${this.value}`;
+    }
+}
+
 export class BitsyParser
 {
     static parse(lines: string[]): BitsyWorld
@@ -204,6 +216,7 @@ export class BitsyParser
             else if (this.checkLine("TIL")) this.takeTile();
             else if (this.checkLine("SPR")) this.takeSprite();
             else if (this.checkLine("ITM")) this.takeItem();
+            else if (this.checkLine("VAR")) this.takeVariable();
             else
             {
                 while (!this.checkBlank())
@@ -443,5 +456,14 @@ export class BitsyParser
         this.tryTakeObjectPalette(item);
 
         this.world.items[item.id] = item;
+    }
+
+    private takeVariable(): void
+    {
+        const variable = new BitsyVariable();
+        this.takeResourceID(variable);
+        variable.value = this.takeLine();
+
+        this.world.variables[variable.id] = variable;
     }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -234,12 +234,17 @@ export class BitsyParser
     {
         const graphic: BitsyGraphic = [];
 
+        let moreFrames;
         do
         {
             graphic.push(this.takeFrame());
+            moreFrames = this.checkLine(">");
+            if(moreFrames) {
+                this.skipLine();
+            }
         }
-        while (this.checkLine(">"));
-        
+        while (moreFrames);
+
         object.graphic = graphic;
     }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -26,23 +26,30 @@ export class BitsyResourceBase implements BitsyResource
 
 export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
 {
+    static paletteDefault: number = 1;
     public graphic: BitsyGraphic = [];
-    public palette: number = 1;
+    public palette: number;
+    constructor() {
+        super();
+        const bob = <typeof BitsyObjectBase>this.constructor;
+        this.palette = bob.paletteDefault;
+    }
 }
 
 export class BitsyTile extends BitsyObjectBase
 {
-    public palette: number = 1;
+    static paletteDefault: number = 1;
 }
 
 export class BitsySprite extends BitsyObjectBase
 {
-    public palette: number = 2;
+    static paletteDefault: number = 2;
     public dialogueID: string = "";
 }
 
 export class BitsyItem extends BitsyObjectBase
 {
+    static paletteDefault: number = 2;
     public dialogueID: string = "";
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -122,13 +122,6 @@ export class BitsyPalette extends BitsyResourceBase
     static typeName: string = "PAL";
     public colors: number[] = [];
 
-    public constructor()
-    {
-        super();
-
-        this.colors = [];
-    }
-
     public get background(): number { return this.colors[0]; }
     public get tile(): number { return this.colors[1]; }
     public get sprite(): number { return this.colors[2]; }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,7 +15,7 @@ TODO: version
 
 TODO: room format
 
-TODO: palettes
+${valuesToString(this.palettes)}
 
 TODO: rooms
 
@@ -129,6 +129,10 @@ export class BitsyPalette extends BitsyResourceBase
     public get background(): number { return this.colors[0]; }
     public get tile(): number { return this.colors[1]; }
     public get sprite(): number { return this.colors[2]; }
+    public toString() {
+        return `${this.type.typeName} ${this.id}
+${this.colors.map(c => `${(c >> 16) & 255},${(c >> 8) & 255},${c & 255}`).join('\n')}`;
+    }
 }
 
 export class BitsyParser

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,6 +27,7 @@ export class BitsyResourceBase implements BitsyResource
 export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
 {
     static paletteDefault: number = 1;
+    static typeName: string = "";
     public graphic: BitsyGraphic = [];
     public palette: number;
     public dialogueID: string = "";
@@ -44,16 +45,19 @@ export class BitsyObjectBase extends BitsyResourceBase implements BitsyObject
 export class BitsyTile extends BitsyObjectBase
 {
     static paletteDefault: number = 1;
+    static typeName: string = "TIL";
 }
 
 export class BitsySprite extends BitsyObjectBase
 {
     static paletteDefault: number = 2;
+    static typeName: string = "SPR";
 }
 
 export class BitsyItem extends BitsyObjectBase
 {
     static paletteDefault: number = 2;
+    static typeName: string = "ITM";
 }
 
 export type BitsyGraphicFrame = boolean[];

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,10 @@
 import { numToRgbString, rgbStringToNum } from "./colourUtils";
 
+function parsePosition(str: string) {
+    const [x, y] = str.split(",").map(n => parseInt(n, 10));
+    return { x, y };
+}
+
 export class BitsyWorld
 {
     public rooms: {[index:string]: BitsyRoom} = {};
@@ -279,8 +284,7 @@ export class BitsyParser
         if (this.checkLine("POS"))
         {
             const [room, pos] = this.takeSplitOnce(" ")[1].split(" ");
-            const [x, y] = pos.split(",");
-            sprite.position = { room, x: parseInt(x, 10), y: parseInt(y, 10) };
+            sprite.position = { room, ...parsePosition(pos) };
         }
     }
 
@@ -335,23 +339,19 @@ export class BitsyParser
     private takeRoomItem(room: BitsyRoom) {
         const item = this.takeSplitOnce(" ")[1];
         const [id, pos] = item.split(" ");
-        const [x, y] = pos.split(",");
-        room.items.push({ id, x: parseInt(x, 10), y: parseInt(y, 10) });
+        room.items.push({ id, ...parsePosition(pos) });
     }
 
     private takeRoomExit(room: BitsyRoom) {
         const exit = this.takeSplitOnce(" ")[1];
         const [from, toRoom, toPos, _, transition] = exit.split(" ");
-        const [x, y] = from.split(",");
-        const [toX, toY] = toPos.split(",");
-        room.exits.push({ from: { x: parseInt(x, 10), y: parseInt(y, 10) }, to: { room: toRoom, x: parseInt(toX, 10), y: parseInt(toY, 10) }, transition });
+        room.exits.push({ from: parsePosition(from), to: { room: toRoom, ...parsePosition(toPos) }, transition });
     }
 
     private takeRoomEnding(room: BitsyRoom) {
         const ending = this.takeSplitOnce(" ")[1];
         const [id, pos] = ending.split(" ");
-        const [x, y] = pos.split(",");
-        room.endings.push({ id, x: parseInt(x, 10), y: parseInt(y, 10) });
+        room.endings.push({ id, ...parsePosition(pos) });
     }
 
     private takeRoomPalette(room: BitsyRoom) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,6 +7,9 @@ function parsePosition(str: string) {
 
 export class BitsyWorld
 {
+    public title: string = "";
+    public bitsyVersion: string = "";
+    public roomFormat: number = 1;
     public rooms: {[index:string]: BitsyRoom} = {};
     public palettes: {[index:string]: BitsyPalette} = {};
     public tiles: {[index:string]: BitsyTile} = {};
@@ -16,12 +19,11 @@ export class BitsyWorld
         function valuesToString(obj: {[index:string]: BitsyResource}) {
             return Object.keys(obj).map(s => obj[s].toString()).join('\n\n');
         }
-        return `
-TODO: title
+        return `${this.title}
 
-TODO: version
+# BITSY VERSION ${this.bitsyVersion}
 
-TODO: room format
+! ROOM_FORMAT ${this.roomFormat}
 
 ${valuesToString(this.palettes)}
 
@@ -184,6 +186,16 @@ export class BitsyParser
     {
         this.reset();
         this.lines = lines;
+
+        this.world.title = this.takeLine();
+        while(!this.done && !this.checkLine("# BITSY VERSION ")) {
+            this.skipLine();
+        }
+        this.world.bitsyVersion = this.takeSplitOnce("# BITSY VERSION ")[1];
+        while(!this.done && !this.checkLine("! ROOM_FORMAT ")) {
+            this.skipLine();
+        }
+        this.world.roomFormat = parseInt(this.takeSplitOnce("! ROOM_FORMAT ")[1], 10);
 
         while (!this.done)
         {

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # @bitsy/parser
-A Node.js module that parses bitsy gamedata. Does not parse rooms or dialogue at this time.
+A Node.js module that parses bitsy gamedata.
 
 ## Installation 
 ```sh


### PR DESCRIPTION
- adds parsing for:
  - rooms
  - dialogue (just pulls the whole script into a string; doesn't actually parse the scripting itself)
  - variables
  - endings
  - all known props for individual resources
  - title
  - version
  - room format (never actually looked into what this does so presumably only supports `1`)
- adds serialization
- bugfixes:
  - animated graphics (was missing handling for `>` line)
  - palette colours (they were reversed)